### PR TITLE
Remove array type hint in with method.

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -389,10 +389,10 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     /**
      * Load relations
      *
-     * @param array $relations
+     * @param array|string $relations
      * @return $this
      */
-    public function with(array $relations)
+    public function with($relations)
     {
         $this->model = $this->model->with($relations);
         return $this;


### PR DESCRIPTION
`with` method supports array or string. No point in forcing to use array.

Was working on a project where it was throwing an error because i was passing a string. Makes sense to not force.