### PR TITLE
Make transformer stub PSR-2 compliant

### DIFF
--- a/src/Prettus/Repository/Generators/Stubs/transformer/transformer.stub
+++ b/src/Prettus/Repository/Generators/Stubs/transformer/transformer.stub
@@ -18,7 +18,8 @@ class $CLASS$Transformer extends TransformerAbstract
      *
      * @return array
      */
-    public function transform($CLASS$ $model) {
+    public function transform($CLASS$ $model)
+    {
         return [
             'id'         => (int)$model->id,
 


### PR DESCRIPTION
I've dropped the opening brace for the transformer stub's transform() method down with a newline to make the definition PSR-2 compliant.